### PR TITLE
Add cross-platform stubs and Emscripten build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ desktop.ini
 *.vcxproj.user
 /temp/
 /Releases
+emsdk/
+augmentinel.html
+augmentinel.js
+augmentinel.wasm

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -32,7 +32,12 @@ For more details see: https://simonowen.com/spectrum/augmentinel/
 Building currently requires Visual Studio 2019 or later.
 
 The current code uses the Win32 and D3D11 APIs so it's not yet portable to
-non-Windows platforms. It's hoped that will change in the future.
+non-Windows platforms. Experimental work has begun on an
+[Emscripten](https://emscripten.org/) port to run the game in a web browser,
+with early `src/game` and `src/render` modules providing platform-neutral
+stubs. See `docs/emscripten-port.md` for the current roadmap.
+`build_web.sh` invokes `em++` to compile these stubs into `augmentinel.html`
+for experimentation.
 
 ## License
 

--- a/build_web.sh
+++ b/build_web.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a minimal WebAssembly version of Augmentinel using Emscripten.
+# The script assumes the Emscripten SDK lives in ./emsdk. If the em++
+# compiler isn't on PATH we source the SDK environment.
+
+ROOT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+if ! command -v em++ >/dev/null 2>&1; then
+  if [[ -f "$ROOT_DIR/emsdk/emsdk_env.sh" ]]; then
+    source "$ROOT_DIR/emsdk/emsdk_env.sh" > /dev/null
+  else
+    echo "Emscripten SDK not found. Install it into $ROOT_DIR/emsdk" >&2
+    exit 1
+  fi
+fi
+
+em++ \
+  src/emscripten_main.cpp \
+  src/game/GameState.cpp \
+  src/render/Renderer.cpp \
+  -std=c++17 -O2 -sWASM=1 \
+  -o augmentinel.html
+

--- a/docs/emscripten-port.md
+++ b/docs/emscripten-port.md
@@ -1,0 +1,31 @@
+# Emscripten Port Plan
+
+This document outlines the initial steps required to port **Augmentinel** to run in a web browser using [Emscripten](https://emscripten.org/).
+
+## Goals
+
+* Compile the core game logic to WebAssembly.
+* Replace platform specific APIs (Win32, D3D11, XAudio) with web friendly alternatives.
+* Provide an entry point and build scripts for Emscripten builds.
+
+## Initial Steps
+
+1. **Ignore local SDK files.**
+   The Emscripten SDK is large and should not be committed. Update `.gitignore` to exclude the `emsdk/` directory.
+2. **Add a web entry point.**
+   Introduce a minimal `main` function guarded by `__EMSCRIPTEN__` so the project can produce a WebAssembly target without touching the existing Windows specific code paths.
+3. **Isolate game logic and rendering.**
+   Begin separating platform neutral game logic and 3D rendering into `src/game` and `src/render` modules. The Emscripten `main` now drives these stubs via `emscripten_set_main_loop`.
+4. **Stub platform headers.**
+   When compiling with Emscripten the Windows headers are unavailable. Create minimal type aliases so the code can be compiled without the Win32 headers.
+5. **Add a web build script.**
+   A `build_web.sh` helper script compiles the stub modules into `augmentinel.html`, `augmentinel.js` and `augmentinel.wasm` using `em++`.
+
+## Next Steps
+
+* Replace the Win32 windowing and message loop with an event loop driven by `emscripten_set_main_loop`.
+* Migrate rendering from D3D11 to WebGL via OpenGL ES 3.0.
+* Replace XAudio2 based audio with the Emscripten WebAudio API.
+* Ensure required assets are preloaded using the Emscripten virtual file system.
+
+These steps lay the groundwork for a full browser port while keeping the existing Windows build intact.

--- a/src/emscripten_main.cpp
+++ b/src/emscripten_main.cpp
@@ -1,0 +1,24 @@
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#include "game/GameState.h"
+#include "render/Renderer.h"
+
+static GameState g_game;
+static Renderer g_renderer;
+
+static void MainLoop()
+{
+    g_game.Update(1.0f / 60.0f);
+    g_renderer.Render();
+}
+
+int main()
+{
+    if (!g_renderer.Init())
+        return 1;
+
+    emscripten_set_main_loop(MainLoop, 0, true);
+    return 0;
+}
+#endif // __EMSCRIPTEN__
+

--- a/src/game/GameState.cpp
+++ b/src/game/GameState.cpp
@@ -1,0 +1,7 @@
+#include "GameState.h"
+
+void GameState::Update(float /*dt*/)
+{
+    // TODO: implement game logic
+}
+

--- a/src/game/GameState.h
+++ b/src/game/GameState.h
@@ -1,0 +1,8 @@
+#pragma once
+
+class GameState {
+public:
+    // Advance game simulation by the given time step (in seconds)
+    void Update(float dt);
+};
+

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1,0 +1,15 @@
+#include "Renderer.h"
+#include <cstdio>
+
+bool Renderer::Init()
+{
+    // Placeholder for renderer initialisation
+    std::puts("Renderer initialised");
+    return true;
+}
+
+void Renderer::Render()
+{
+    // TODO: draw a frame
+}
+

--- a/src/render/Renderer.h
+++ b/src/render/Renderer.h
@@ -1,0 +1,8 @@
+#pragma once
+
+class Renderer {
+public:
+    bool Init();
+    void Render();
+};
+

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -22,6 +22,7 @@
 #include <filesystem>
 namespace fs = std::filesystem;
 
+#ifndef __EMSCRIPTEN__
 #define NOMINMAX
 #include <windows.h>
 #include <windowsx.h>
@@ -48,7 +49,6 @@ namespace fs = std::filesystem;
 #include <xapofx.h>
 #endif
 
-
 #ifdef _WIN64
 constexpr auto X3D_HRTF_HOOK_DLL = L"hrtf/x64/x3daudio1_7.dll";
 #else
@@ -64,6 +64,17 @@ using Microsoft::WRL::ComPtr;
 #pragma comment(lib, "d3d11.lib")
 #include <DirectXMath.h>
 using namespace DirectX;
+#else
+// Minimal Win32 type stubs for Emscripten builds.
+using HINSTANCE = void*;
+using HWND = void*;
+using WPARAM = unsigned long;
+using LPARAM = long;
+using LRESULT = long;
+using UINT = unsigned int;
+#define CALLBACK
+#define WINAPI
+#endif
 
 #include "SharedConstants.h"
 #include "Utils.h"


### PR DESCRIPTION
## Summary
- introduce placeholder `GameState` and `Renderer` modules for platform-neutral game logic and 3D work
- drive these stubs from an Emscripten main loop
- add `build_web.sh` helper to compile the stubs into a browser test build
- document the script and ignore generated WebAssembly artifacts

## Testing
- `./emsdk/emsdk list`
- `em++ --version`
- `./build_web.sh && ls -l augmentinel.html augmentinel.js augmentinel.wasm`


------
https://chatgpt.com/codex/tasks/task_e_68b0c95ee32483318bf46b8d9e7330b4