### PR TITLE
feat: add stub WebGL2 renderer for Emscripten port

### DIFF
--- a/build_web.sh
+++ b/build_web.sh
@@ -2,16 +2,19 @@
 set -euo pipefail
 
 # Build a minimal WebAssembly version of Augmentinel using Emscripten.
-# The script assumes the Emscripten SDK lives in ./emsdk. If the em++
-# compiler isn't on PATH we source the SDK environment.
+# The script assumes the Emscripten SDK lives in ./emsdk or the global
+# /usr/local/emsdk install. If the em++ compiler isn't on PATH we source
+# the SDK environment.
 
 ROOT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 if ! command -v em++ >/dev/null 2>&1; then
   if [[ -f "$ROOT_DIR/emsdk/emsdk_env.sh" ]]; then
     source "$ROOT_DIR/emsdk/emsdk_env.sh" > /dev/null
+  elif [[ -f "/usr/local/emsdk/emsdk_env.sh" ]]; then
+    source "/usr/local/emsdk/emsdk_env.sh" > /dev/null
   else
-    echo "Emscripten SDK not found. Install it into $ROOT_DIR/emsdk" >&2
+    echo "Emscripten SDK not found. Install it into $ROOT_DIR/emsdk or /usr/local/emsdk" >&2
     exit 1
   fi
 fi
@@ -20,6 +23,6 @@ em++ \
   src/emscripten_main.cpp \
   src/game/GameState.cpp \
   src/render/Renderer.cpp \
-  -std=c++17 -O2 -sWASM=1 \
+  -std=c++17 -O2 -sWASM=1 -sUSE_WEBGL2=1 -sFULL_ES3=1 \
   -o augmentinel.html
 

--- a/docs/emscripten-port.md
+++ b/docs/emscripten-port.md
@@ -20,11 +20,13 @@ This document outlines the initial steps required to port **Augmentinel** to run
    When compiling with Emscripten the Windows headers are unavailable. Create minimal type aliases so the code can be compiled without the Win32 headers.
 5. **Add a web build script.**
    A `build_web.sh` helper script compiles the stub modules into `augmentinel.html`, `augmentinel.js` and `augmentinel.wasm` using `em++`.
+   The script automatically sources the Emscripten SDK environment from a local `emsdk/` directory or a global `/usr/local/emsdk` install.
 
 ## Next Steps
 
 * Replace the Win32 windowing and message loop with an event loop driven by `emscripten_set_main_loop`.
 * Migrate rendering from D3D11 to WebGL via OpenGL ES 3.0.
+  A stub renderer now creates a WebGL2 context and clears the screen each frame.
 * Replace XAudio2 based audio with the Emscripten WebAudio API.
 * Ensure required assets are preloaded using the Emscripten virtual file system.
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1,15 +1,36 @@
 #include "Renderer.h"
 #include <cstdio>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten/html5.h>
+#include <GLES3/gl3.h>
+static EMSCRIPTEN_WEBGL_CONTEXT_HANDLE g_ctx = 0;
+#endif
+
 bool Renderer::Init()
 {
-    // Placeholder for renderer initialisation
+#ifdef __EMSCRIPTEN__
+    EmscriptenWebGLContextAttributes attr;
+    emscripten_webgl_init_context_attributes(&attr);
+    attr.majorVersion = 2;
+    attr.minorVersion = 0;
+    g_ctx = emscripten_webgl_create_context("#canvas", &attr);
+    if (g_ctx <= 0) {
+        std::puts("Failed to create WebGL2 context");
+        return false;
+    }
+    emscripten_webgl_make_context_current(g_ctx);
+#endif
     std::puts("Renderer initialised");
     return true;
 }
 
 void Renderer::Render()
 {
+#ifdef __EMSCRIPTEN__
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+#endif
     // TODO: draw a frame
 }
 


### PR DESCRIPTION
## Summary
- initialize a WebGL2 context when building under Emscripten and clear the screen each frame
- enable WebGL2/ES3 flags in the web build script and source the SDK from a global `/usr/local/emsdk` install when needed
- document the initial WebGL renderer progress in the Emscripten port plan and note automatic SDK sourcing

## Testing
- `./build_web.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b0cfb05f788331b7382d044f575580